### PR TITLE
Fix issue where labels are all the same due to map being a pointer

### DIFF
--- a/runner/result.go
+++ b/runner/result.go
@@ -29,7 +29,10 @@ func (h *apiHelper) CreateFindings(ctx context.Context, finds []*proto.Finding) 
 	// Merge agent, config and finding labels all together.
 	resultFindings := make([]types.Finding, 0)
 	for _, finding := range findings {
-		labels := h.agentLabels
+		labels := make(map[string]string)
+		for k, v := range h.agentLabels {
+			labels[k] = v
+		}
 		for k, v := range finding.Labels {
 			labels[k] = v
 		}


### PR DESCRIPTION
There is currently a bug where all findings from the same plugin have the exact same set of labels, due to the label maps being a pointer. The previous version was trying to add to the map, but due to being a pointer, all other findings where referencing the same map. 
This is now fixed by copying the map to a new map and using that on the finding.