### PR TITLE
fix: prevents paanic on violations as array

### DIFF
--- a/policy-manager/policy-manager.go
+++ b/policy-manager/policy-manager.go
@@ -126,6 +126,38 @@ func writePolicyDataValue(ctx context.Context, store storage.Store, txn storage.
 	return nil
 }
 
+// normalizeViolationEntries converts OPA's two possible serializations of a
+// `violation` rule into a uniform list of JSON byte slices that can be decoded
+// into a Violation via the same path.
+//
+// Partial object rule (`violation[obj] := ...` / `violation[obj]`): OPA returns
+// a map[string]interface{} whose keys are JSON-encoded violation objects.
+//
+// Set rule (`violation contains {...}`): OPA returns a []interface{} whose
+// elements are already-decoded violation objects.
+func normalizeViolationEntries(val interface{}) ([][]byte, error) {
+	switch v := val.(type) {
+	case map[string]interface{}:
+		entries := make([][]byte, 0, len(v))
+		for key := range v {
+			entries = append(entries, []byte(key))
+		}
+		return entries, nil
+	case []interface{}:
+		entries := make([][]byte, 0, len(v))
+		for _, item := range v {
+			raw, err := json.Marshal(item)
+			if err != nil {
+				return nil, fmt.Errorf("re-encode violation entry: %w", err)
+			}
+			entries = append(entries, raw)
+		}
+		return entries, nil
+	default:
+		return nil, fmt.Errorf("unexpected violations type %T, want map or slice", val)
+	}
+}
+
 func (pm *PolicyManager) Execute(ctx context.Context, input interface{}) ([]Result, error) {
 	var output []Result
 
@@ -178,35 +210,22 @@ func (pm *PolicyManager) Execute(ctx context.Context, input interface{}) ([]Resu
 				violations := make([]Violation, 0)
 
 				if val, ok := moduleOutputs["violation"]; ok {
-					switch v := val.(type) {
-					case map[string]interface{}:
-						// Partial object rule: `violation[obj] := ...` — keys are
-						// JSON-encoded violation objects.
-						for violation := range v {
-							viol := &Violation{}
-							if err := json.Unmarshal([]byte(violation), viol); err != nil {
-								return nil, err
-							}
-							violations = append(violations, *viol)
-						}
-					case []interface{}:
-						// Set rule: `violation contains {...}` — each element is
-						// already a decoded violation object.
-						for _, item := range v {
-							viol := &Violation{}
-							if err := mapstructure.Decode(item, viol); err != nil {
-								return nil, fmt.Errorf(
-									"decode violation entry (policy package %q, file %q): %w",
-									result.Policy.Package, result.Policy.File, err,
-								)
-							}
-							violations = append(violations, *viol)
-						}
-					default:
+					rawEntries, err := normalizeViolationEntries(val)
+					if err != nil {
 						return nil, fmt.Errorf(
-							"unexpected violations type %T (policy package %q, file %q)",
-							val, result.Policy.Package, result.Policy.File,
+							"%w (policy package %q, file %q)",
+							err, result.Policy.Package, result.Policy.File,
 						)
+					}
+					for _, raw := range rawEntries {
+						viol := &Violation{}
+						if err := json.Unmarshal(raw, viol); err != nil {
+							return nil, fmt.Errorf(
+								"decode violation entry (policy package %q, file %q): %w",
+								result.Policy.Package, result.Policy.File, err,
+							)
+						}
+						violations = append(violations, *viol)
 					}
 				}
 

--- a/policy-manager/policy-manager.go
+++ b/policy-manager/policy-manager.go
@@ -176,6 +176,15 @@ func (pm *PolicyManager) Execute(ctx context.Context, input interface{}) ([]Resu
 			continue
 		}
 
+		// Only treat packages under the compliance_framework namespace as
+		// evaluable policies. Packages in other namespaces (e.g. shared helper
+		// libraries under ccf_libs) are bundled for import only and must not be
+		// evaluated as policies, as they intentionally produce no title/evidence.
+		packagePath := module.Package.Path.String()
+		if packagePath != "data.compliance_framework" && !strings.HasPrefix(packagePath, "data.compliance_framework.") {
+			continue
+		}
+
 		result := Result{
 			Policy: Policy{
 				File:        module.Package.Location.File,

--- a/policy-manager/policy-manager.go
+++ b/policy-manager/policy-manager.go
@@ -168,14 +168,27 @@ func (pm *PolicyManager) Execute(ctx context.Context, input interface{}) ([]Resu
 
 		for _, eval := range evaluation {
 			for _, expression := range eval.Expressions {
-				moduleOutputs := expression.Value.(map[string]interface{})
+				moduleOutputs, ok := expression.Value.(map[string]interface{})
+				if !ok {
+					return nil, fmt.Errorf(
+						"expected module outputs to be a map (policy package %q, file %q)",
+						result.Policy.Package, result.Policy.File,
+					)
+				}
 				violations := make([]Violation, 0)
 
 				val, ok := moduleOutputs["violation"]
 				// If the key exists
 				if ok {
-					// Do something
-					for violation, _ := range val.(map[string]interface{}) {
+					violationsMap, ok := val.(map[string]interface{})
+					if !ok {
+						return nil, fmt.Errorf(
+							"expected violations to be a map, but it was processed as a slice (policy package %q, file %q): "+
+								"define `violation` as a partial object rule (violation[msg] := obj) rather than a set (violation contains {...})",
+							result.Policy.Package, result.Policy.File,
+						)
+					}
+					for violation := range violationsMap {
 						viol := &Violation{}
 						err := json.Unmarshal([]byte(violation), viol)
 						if err != nil {
@@ -190,11 +203,11 @@ func (pm *PolicyManager) Execute(ctx context.Context, input interface{}) ([]Resu
 					Violations:          violations,
 				}
 
-				fmt.Println(expression.Value.(map[string]interface{}))
-
-				err := mapstructure.Decode(expression.Value.(map[string]interface{}), evalOutput)
-				if err != nil {
-					panic(err)
+				if err := mapstructure.Decode(moduleOutputs, evalOutput); err != nil {
+					return nil, fmt.Errorf(
+						"decode policy outputs (policy package %q, file %q): %w",
+						result.Policy.Package, result.Policy.File, err,
+					)
 				}
 
 				// TODO here we could run evalOutput.Validate()

--- a/policy-manager/policy-manager.go
+++ b/policy-manager/policy-manager.go
@@ -177,24 +177,36 @@ func (pm *PolicyManager) Execute(ctx context.Context, input interface{}) ([]Resu
 				}
 				violations := make([]Violation, 0)
 
-				val, ok := moduleOutputs["violation"]
-				// If the key exists
-				if ok {
-					violationsMap, ok := val.(map[string]interface{})
-					if !ok {
-						return nil, fmt.Errorf(
-							"expected violations to be a map, but it was processed as a slice (policy package %q, file %q): "+
-								"define `violation` as a partial object rule (violation[msg] := obj) rather than a set (violation contains {...})",
-							result.Policy.Package, result.Policy.File,
-						)
-					}
-					for violation := range violationsMap {
-						viol := &Violation{}
-						err := json.Unmarshal([]byte(violation), viol)
-						if err != nil {
-							return nil, err
+				if val, ok := moduleOutputs["violation"]; ok {
+					switch v := val.(type) {
+					case map[string]interface{}:
+						// Partial object rule: `violation[obj] := ...` — keys are
+						// JSON-encoded violation objects.
+						for violation := range v {
+							viol := &Violation{}
+							if err := json.Unmarshal([]byte(violation), viol); err != nil {
+								return nil, err
+							}
+							violations = append(violations, *viol)
 						}
-						violations = append(violations, *viol)
+					case []interface{}:
+						// Set rule: `violation contains {...}` — each element is
+						// already a decoded violation object.
+						for _, item := range v {
+							viol := &Violation{}
+							if err := mapstructure.Decode(item, viol); err != nil {
+								return nil, fmt.Errorf(
+									"decode violation entry (policy package %q, file %q): %w",
+									result.Policy.Package, result.Policy.File, err,
+								)
+							}
+							violations = append(violations, *viol)
+						}
+					default:
+						return nil, fmt.Errorf(
+							"unexpected violations type %T (policy package %q, file %q)",
+							val, result.Policy.Package, result.Policy.File,
+						)
 					}
 				}
 

--- a/policy-manager/policy-manager_test.go
+++ b/policy-manager/policy-manager_test.go
@@ -87,7 +87,7 @@ func TestPolicyManager(t *testing.T) {
 		}, result.Violations[0])
 	})
 
-	t.Run("Policy Manager returns descriptive error when violation is a set", func(t *testing.T) {
+	t.Run("Policy Manager handles violations defined as a set", func(t *testing.T) {
 		ctx := context.Background()
 
 		regoContents := []byte(`package compliance_framework.set_violation
@@ -95,7 +95,11 @@ func TestPolicyManager(t *testing.T) {
 import future.keywords.contains
 import future.keywords.if
 
-violation contains {"title": "Violation 1"} if {
+violation contains {
+	"title": "Violation 1",
+	"description": "You have been violated.",
+	"remarks": "Migrate to not being violated",
+} if {
 	input.violated
 }
 `)
@@ -103,12 +107,18 @@ violation contains {"title": "Violation 1"} if {
 		var data map[string]interface{} = make(map[string]interface{})
 		data["violated"] = true
 
-		_, err := buildPolicyManager(regoContents).Execute(ctx, data)
+		results, err := buildPolicyManager(regoContents).Execute(ctx, data)
 
-		if assert.Error(t, err) {
-			assert.Contains(t, err.Error(), "expected violations to be a map, but it was processed as a slice")
-			assert.Contains(t, err.Error(), "compliance_framework.set_violation")
-		}
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(results))
+
+		result := results[0]
+		assert.Equal(t, 1, len(result.Violations))
+		assert.Equal(t, Violation{
+			Title:       Pointer("Violation 1"),
+			Description: Pointer("You have been violated."),
+			Remarks:     Pointer("Migrate to not being violated"),
+		}, result.Violations[0])
 	})
 
 	t.Run("Policy Manager injects dynamic policy data as OPA data", func(t *testing.T) {

--- a/policy-manager/policy-manager_test.go
+++ b/policy-manager/policy-manager_test.go
@@ -104,8 +104,7 @@ violation contains {
 }
 `)
 
-		var data map[string]interface{} = make(map[string]interface{})
-		data["violated"] = true
+		data := map[string]interface{}{"violated": true}
 
 		results, err := buildPolicyManager(regoContents).Execute(ctx, data)
 

--- a/policy-manager/policy-manager_test.go
+++ b/policy-manager/policy-manager_test.go
@@ -87,6 +87,30 @@ func TestPolicyManager(t *testing.T) {
 		}, result.Violations[0])
 	})
 
+	t.Run("Policy Manager returns descriptive error when violation is a set", func(t *testing.T) {
+		ctx := context.Background()
+
+		regoContents := []byte(`package compliance_framework.set_violation
+
+import future.keywords.contains
+import future.keywords.if
+
+violation contains {"title": "Violation 1"} if {
+	input.violated
+}
+`)
+
+		var data map[string]interface{} = make(map[string]interface{})
+		data["violated"] = true
+
+		_, err := buildPolicyManager(regoContents).Execute(ctx, data)
+
+		if assert.Error(t, err) {
+			assert.Contains(t, err.Error(), "expected violations to be a map, but it was processed as a slice")
+			assert.Contains(t, err.Error(), "compliance_framework.set_violation")
+		}
+	})
+
 	t.Run("Policy Manager injects dynamic policy data as OPA data", func(t *testing.T) {
 		ctx := context.Background()
 		policyDir := t.TempDir()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Policies are now filtered to the compliance framework namespace; only relevant packages are evaluated.
  * More robust handling of policy outputs: validates shapes before decoding, returns clear contextual errors (policy package + file) instead of crashes or debug prints.

* **Tests**
  * Added test coverage for policies that emit violations as a set to ensure correct decoding and single-violation results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->